### PR TITLE
fix runtime env vars

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -63,7 +63,6 @@ jobs:
           cache-to: type=gha,mode=max,scope=staging
           build-args: |
             VERSION=${{ needs.calculate-version.outputs.version }}
-            PUBLIC_API_SERVER_URL=https://staging.devpad.tools/api/v0
             
   deploy-to-staging:
     runs-on: ubuntu-latest

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -23,9 +23,6 @@ COPY todo-config.json .
 COPY --from=go-builder /todo-tracker/todo-tracker .
 
 # Build the Astro app (creates dist folder with static assets and SSR handler)
-# Accept PUBLIC_API_SERVER_URL as a build argument
-ARG PUBLIC_API_SERVER_URL
-ENV PUBLIC_API_SERVER_URL=${PUBLIC_API_SERVER_URL}
 
 # Install all workspace dependencies
 RUN bun install --frozen-lockfile

--- a/deployment/docker-cleanup.sh
+++ b/deployment/docker-cleanup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Script to properly stop and clean up Docker containers on the VPS
+
+echo "🔍 Checking running containers..."
+sudo docker ps
+
+echo -e "\n📦 Stopping devpad containers..."
+# Stop all devpad containers regardless of how they were started
+sudo docker stop devpad-production devpad-staging 2>/dev/null || true
+
+echo -e "\n🗑️  Removing stopped containers..."
+sudo docker rm devpad-production devpad-staging 2>/dev/null || true
+
+echo -e "\n🔍 Checking if network is still in use..."
+NETWORK_CONTAINERS=$(sudo docker network inspect devpad_default -f '{{range .Containers}}{{.Name}} {{end}}' 2>/dev/null)
+
+if [ -n "$NETWORK_CONTAINERS" ]; then
+    echo "⚠️  Network still used by: $NETWORK_CONTAINERS"
+    echo "Stopping those containers..."
+    for container in $NETWORK_CONTAINERS; do
+        sudo docker stop $container 2>/dev/null || true
+    done
+fi
+
+echo -e "\n🧹 Cleaning up network..."
+sudo docker network rm devpad_default 2>/dev/null || true
+
+echo -e "\n✅ Cleanup complete!"
+echo -e "\n📋 Current status:"
+sudo docker ps

--- a/deployment/docker-compose.production.yml
+++ b/deployment/docker-compose.production.yml
@@ -13,6 +13,7 @@ services:
       - STATIC_FILES_PATH=./packages/app/dist/client
       - CORS_ORIGINS=https://devpad.tools,https://www.devpad.tools
       - FRONTEND_URL=https://devpad.tools
+      - PUBLIC_API_SERVER_URL=https://devpad.tools/api/v0
     volumes:
       - devpad_production_data:/app/data
       - /var/log/devpad/production:/app/logs

--- a/deployment/docker-compose.staging.yml
+++ b/deployment/docker-compose.staging.yml
@@ -14,6 +14,7 @@ services:
       CORS_ORIGINS: https://staging.devpad.tools
       FRONTEND_URL: https://staging.devpad.tools
       MODE: production
+      PUBLIC_API_SERVER_URL: https://staging.devpad.tools/api/v0
       GITHUB_CLIENT_SECRET:
       GITHUB_CLIENT_ID:
     volumes:

--- a/packages/app/src/components/solid/GithubLogin.tsx
+++ b/packages/app/src/components/solid/GithubLogin.tsx
@@ -6,10 +6,8 @@ export default function GithubLogin({ size = 20 }: { size?: number }) {
 
 	const login = async () => {
 		setState("loading");
-		// Get API server URL from environment variable or default to port 3001
-		const api_server = import.meta.env.PUBLIC_API_SERVER_URL || "http://localhost:3001/api/v0";
-		const base = api_server.replace("/api/v0", "");
-		window.location.href = `${base}/api/auth/login`;
+		// Use current origin for auth redirect (works for both staging and production)
+		window.location.href = `${window.location.origin}/api/auth/login`;
 	};
 
 	return (

--- a/packages/app/src/middleware.ts
+++ b/packages/app/src/middleware.ts
@@ -11,7 +11,7 @@ const log = {
 const history_ignore = ["/api", "/favicon", "/images", "/public"];
 const origin_ignore = ["/api"];
 
-const API_SERVER_URL = import.meta.env.PUBLIC_API_SERVER_URL || "http://localhost:3001/api/v0";
+const API_SERVER_URL = process.env.PUBLIC_API_SERVER_URL || "http://localhost:3001/api/v0";
 const API_SERVER_BASE = API_SERVER_URL.replace("/api/v0", "") || "http://localhost:3001";
 
 export const onRequest: MiddlewareHandler = defineMiddleware(async (context, next) => {

--- a/packages/app/src/utils/api-client.ts
+++ b/packages/app/src/utils/api-client.ts
@@ -21,8 +21,8 @@ export function getApiClient(): ApiClient {
 		return _apiClient;
 	}
 
-	// Get API server URL from environment variable or default to current origin + /api/v0
-	const serverUrl = import.meta.env.PUBLIC_API_SERVER_URL || `${window.location.origin}/api/v0`;
+	// Use current origin for API calls (works for both staging and production)
+	const serverUrl = `${window.location.origin}/api/v0`;
 	log.api(" Server URL:", serverUrl);
 
 	// Try JWT token first (session-based auth for normal users)
@@ -230,6 +230,6 @@ export function getServerApiClient(locals: any): ApiClient {
 	});
 }
 
-export function rethrow<T>(error: Result<T, string>['error']) {
-	return new Response(error?.code, { status: error?.status_code, statusText: error?.code});
+export function rethrow<T>(error: Result<T, string>["error"]) {
+	return new Response(error?.code, { status: error?.status_code, statusText: error?.code });
 }


### PR DESCRIPTION
- Remove build-time PUBLIC_API_SERVER_URL from Dockerfile and workflows
- Change middleware to use process.env instead of import.meta.env
- Update client-side code to use window.location.origin
- Add PUBLIC_API_SERVER_URL as runtime env var in docker-compose files
- Fix authentication redirects for production vs staging environments

This allows the same Docker image to work in both staging and production environments without rebuilding, fixing the auth redirect issue.