### PR TITLE
fix: ProjectSelector not pre-selecting project from session context

### DIFF
--- a/apps/main/src/components/solid/ProjectSelector.tsx
+++ b/apps/main/src/components/solid/ProjectSelector.tsx
@@ -1,38 +1,28 @@
 import type { Project } from "@devpad/schema";
-import { createEffect, createSignal, For } from "solid-js";
+import { For, onMount } from "solid-js";
 
-/** solid-js component called <ProjectSelector>, given a map of projects via `project_map`,
- * render a <select> element with the name of each project, and on change call `callback(project_id)`, the prop also accepts `default_id` as a project database ID, otherwise the selected value is empty string
- */
 export function ProjectSelector({ project_map, default_id, callback, disabled }: { project_map: Record<string, Project>; default_id: string | null; callback: (project_id: string | null) => void; disabled: boolean }) {
-	const [selected, setSelected] = createSignal<string>(default_id ?? "");
+	let ref!: HTMLSelectElement;
 
-	createEffect(() => {
-		setSelected(default_id ?? "");
-		callback(default_id === "" ? null : default_id);
+	onMount(() => {
+		if (default_id) {
+			ref.value = default_id;
+		}
 	});
 
 	return (
 		<select
+			ref={ref}
 			id="project-selector"
-			value={selected() ?? ""}
+			value={default_id ?? ""}
 			disabled={disabled}
 			onChange={e => {
 				const project_id = e.target.value;
-				setSelected(project_id ?? "");
 				callback(project_id === "" ? null : project_id);
 			}}
 		>
-			<option value="" selected={selected() === ""}>
-				-
-			</option>
-			<For each={Object.keys(project_map)}>
-				{project_id => (
-					<option value={project_id} selected={project_id === selected()}>
-						{project_map[project_id].name}
-					</option>
-				)}
-			</For>
+			<option value="">-</option>
+			<For each={Object.keys(project_map)}>{project_id => <option value={project_id}>{project_map[project_id].name}</option>}</For>
 		</select>
 	);
 }


### PR DESCRIPTION
SolidJS <For> renders options after <select> value binding, causing the dropdown to fall back to '-'. Use onMount + ref to set the select value after options are in the DOM.