### PR TITLE
chore(wrangler): point pulse_api_base at deployed worker

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -24,7 +24,7 @@ invocation_logs = true
 ENVIRONMENT = "production"
 API_URL = "https://devpad.tools"
 FRONTEND_URL = "https://devpad.tools"
-PULSE_API_BASE = "https://pulse.devpad.tools"
+PULSE_API_BASE = "https://pulse-production-pulseapiscript-doseawwm.dev-818.workers.dev"
 DEVPAD_PROJECT_ID = ""              # set after registering devpad-as-project — leave empty until then
 
 [[d1_databases]]
@@ -53,7 +53,7 @@ routes = [
 ENVIRONMENT = "preview"
 API_URL = "https://staging.devpad.tools"
 FRONTEND_URL = "https://staging.devpad.tools"
-PULSE_API_BASE = "https://pulse.devpad.tools"
+PULSE_API_BASE = "https://pulse-production-pulseapiscript-doseawwm.dev-818.workers.dev"
 DEVPAD_PROJECT_ID = ""              # set after registering devpad-as-project — leave empty until then
 
 [[env.preview.d1_databases]]


### PR DESCRIPTION
## Summary

Custom domain \`pulse.devpad.tools\` isn't configured. Until it is, devpad's worker proxy targets the production pulse workers.dev URL directly. Matches the GitHub variable \`PUBLIC_PULSE_INGEST_URL\` already set for the browser SDK build.

Without this, \`/v1/pulse/*\` proxy fails with DNS / 404 against the unconfigured custom domain.

## Test plan

- [ ] After merge, staging redeploys; \`curl https://staging.devpad.tools/v1/pulse/summary/<project-id>\` (with a valid session) hits production pulse and returns either data or \`pulse_unreachable\` (it's still pulse_unreachable until \`PULSE_INTERNAL_KEY\` is set as a wrangler secret — separate manual step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)