### PR TITLE
fix(auth): /session works for api-key auth (no session cookie)

### DIFF
--- a/packages/worker/src/routes/auth.ts
+++ b/packages/worker/src/routes/auth.ts
@@ -154,7 +154,7 @@ app.get("/session", async c => {
 	const session = c.get("session");
 
 	const api_key_scope = c.get("api_key_scope");
-	if (!user || !session) {
+	if (!user) {
 		return c.json({ authenticated: false, user: null, session: null });
 	}
 
@@ -178,7 +178,7 @@ app.get("/session", async c => {
 					github_id: user.github_id,
 					task_view: user.task_view,
 				},
-		session: { id: session.id },
+		session: session ? { id: session.id } : null,
 		...(api_key_scope && { scope: api_key_scope }),
 	});
 });


### PR DESCRIPTION
## Summary

API-key auth populates `c.get(\"user\")` but leaves `c.get(\"session\")` null (the auth middleware sets `session = null` for bearer-token requests in `middleware/auth.ts:30`). The `/session` route was short-circuiting on `!session` and returning `{ authenticated: false }`, which broke pulse's admin-auth validator: pulse calls `${DEVPAD_API_BASE}/api/auth/session` with the user's bearer to resolve the API key's user_id and scope, and was always seeing `authenticated: false` even for valid keys.

## Change

- Drop `|| !session` from the early-return guard in `routes/auth.ts:151`.
- Make the `session` field in the response nullable (`session: session ? { id: session.id } : null`).

Cookie-based browser sessions populate both `user` and `session` exactly as before — this only adds the API-key path.

## Why now

The Phase 3A intent was to expose `scope` via this endpoint for API-key validation by pulse. The implementation never adapted the early-return, so API-key callers couldn't actually use the response.

## Test plan

- [x] `bun test packages` — 390 pass / 0 fail (matches main baseline)
- [x] `bun run build` in `packages/api` — clean
- [x] Browser cookie auth still returns `authenticated: true` with full user + session (no behavioral change for that path)
- [ ] After merge: pulse `staging.devpad.tools/api/v1/pulse/admin/keys` succeeds with a staging API key