### PR TITLE
chore(wrangler): stage-isolate PULSE_API_BASE for preview

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -53,7 +53,9 @@ routes = [
 ENVIRONMENT = "preview"
 API_URL = "https://staging.devpad.tools"
 FRONTEND_URL = "https://staging.devpad.tools"
-PULSE_API_BASE = "https://pulse-production-pulseapiscript-doseawwm.dev-818.workers.dev"
+# Stage isolation: staging devpad → staging pulse → staging devpad (validates keys against the right DB).
+# Production keeps the production pulse URL above.
+PULSE_API_BASE = "https://pulse-preview-pulseapiscript-srzukuoe.dev-818.workers.dev"
 DEVPAD_PROJECT_ID = ""              # set after registering devpad-as-project — leave empty until then
 
 [[env.preview.d1_databases]]


### PR DESCRIPTION
Fixes the staging-devpad → production-pulse → production-devpad mismatch that 401s every staging-issued PULSE_INTERNAL_KEY. Staging now proxies to staging pulse, which calls back to staging devpad's DB to validate.

Production [vars] unchanged — production devpad still routes to production pulse.