### PR TITLE
fix(pulse): bundle the SDK init instead of bare-specifier dynamic import

### DIFF
--- a/apps/main/src/layouts/Layout.astro
+++ b/apps/main/src/layouts/Layout.astro
@@ -53,16 +53,21 @@ const pulse_ready = Boolean(PULSE_INGEST_URL && DEVPAD_PROJECT_ID && PULSE_INGES
 		{noindex && <meta name="robots" content="noindex, nofollow" />}
 
 		{pulse_ready && (
-			<script is:inline define:vars={{ PULSE_INGEST_URL, DEVPAD_PROJECT_ID, PULSE_INGEST_KEY, RELEASE }}>
-				import("@f0rbit/pulse-client").then(({ createPulse }) => {
-					window.__pulse = createPulse({
-						project_id: DEVPAD_PROJECT_ID,
-						ingest_key: PULSE_INGEST_KEY,
-						endpoint: PULSE_INGEST_URL,
+			<script>
+				import { createPulse } from "@f0rbit/pulse-client";
+				const endpoint = import.meta.env.PUBLIC_PULSE_INGEST_URL;
+				const project_id = import.meta.env.PUBLIC_DEVPAD_PROJECT_ID;
+				const ingest_key = import.meta.env.PUBLIC_DEVPAD_PULSE_INGEST_KEY;
+				const release = import.meta.env.PUBLIC_GIT_SHA;
+				if (endpoint && project_id && ingest_key) {
+					(window as any).__pulse = createPulse({
+						project_id,
+						ingest_key,
+						endpoint,
 						auto_pageview: true,
-						release: RELEASE,
+						release,
 					});
-				});
+				}
 			</script>
 		)}
 	</head>


### PR DESCRIPTION
Browser can't resolve bare specifiers in `is:inline` scripts, so the dynamic import was throwing at runtime and no events reached pulse. Dropping `is:inline` lets Astro bundle the script properly.