### PR TITLE
feat(ui): scope picker for API keys + ingest-key creation on pulse page

### DIFF
--- a/apps/main/src/components/solid/ApiKeyManager.tsx
+++ b/apps/main/src/components/solid/ApiKeyManager.tsx
@@ -21,10 +21,21 @@ const formatDate = (dateString?: string | null) => {
 	});
 };
 
+type ApiKeyScope = "devpad" | "blog" | "media" | "pulse" | "all";
+
+const SCOPE_OPTIONS: { value: ApiKeyScope; label: string }[] = [
+	{ value: "all", label: "all — full access (default)" },
+	{ value: "devpad", label: "devpad — projects, tasks, milestones, goals" },
+	{ value: "pulse", label: "pulse — analytics proxy + admin" },
+	{ value: "blog", label: "blog — blog content + drafts" },
+	{ value: "media", label: "media — timeline + platform connections" },
+];
+
 export default function ApiKeyManager(props: ApiKeyManagerProps) {
 	const [keys, setKeys] = createSignal<ApiKey[]>(props.keys);
 	const [showCreate, setShowCreate] = createSignal(false);
 	const [newKeyName, setNewKeyName] = createSignal("");
+	const [newKeyScope, setNewKeyScope] = createSignal<ApiKeyScope>("all");
 	const [createdKey, setCreatedKey] = createSignal<string | null>(null);
 	const [deleteTarget, setDeleteTarget] = createSignal<ApiKey | null>(null);
 	const [loading, setLoading] = createSignal(false);
@@ -35,7 +46,10 @@ export default function ApiKeyManager(props: ApiKeyManagerProps) {
 		setLoading(true);
 		setError(null);
 		const apiClient = getBrowserClient();
-		const result = await apiClient.auth.keys.create(newKeyName() || undefined);
+		const result = await apiClient.auth.keys.create({
+			name: newKeyName() || undefined,
+			scope: newKeyScope(),
+		});
 		if (!result.ok) {
 			setError(result.error.message ?? "Failed to create key");
 			setLoading(false);
@@ -47,6 +61,7 @@ export default function ApiKeyManager(props: ApiKeyManagerProps) {
 			setKeys(listResult.value);
 		}
 		setNewKeyName("");
+		setNewKeyScope("all");
 		setLoading(false);
 	};
 
@@ -146,9 +161,28 @@ export default function ApiKeyManager(props: ApiKeyManagerProps) {
 					<ModalTitle>Create API Key</ModalTitle>
 				</ModalHeader>
 				<ModalBody>
-					<FormField label="Name (optional)">
-						<Input placeholder="e.g. CI pipeline, local dev" value={newKeyName()} onInput={(e: InputEvent & { currentTarget: HTMLInputElement }) => setNewKeyName(e.currentTarget.value)} />
-					</FormField>
+					<div class="stack stack-sm">
+						<FormField label="Name (optional)">
+							<Input placeholder="e.g. CI pipeline, local dev" value={newKeyName()} onInput={(e: InputEvent & { currentTarget: HTMLInputElement }) => setNewKeyName(e.currentTarget.value)} />
+						</FormField>
+						<FormField label="Scope" description="What this key can do. Defaults to 'all'.">
+							<select
+								value={newKeyScope()}
+								onChange={(e: Event & { currentTarget: HTMLSelectElement }) => setNewKeyScope(e.currentTarget.value as ApiKeyScope)}
+								style={{
+									width: "100%",
+									padding: "0.5rem 0.625rem",
+									"font-size": "var(--text-sm)",
+									background: "var(--bg-alt)",
+									color: "var(--fg)",
+									border: "1px solid var(--border)",
+									"border-radius": "var(--radius, 4px)",
+								}}
+							>
+								<For each={SCOPE_OPTIONS}>{opt => <option value={opt.value}>{opt.label}</option>}</For>
+							</select>
+						</FormField>
+					</div>
 				</ModalBody>
 				<ModalFooter>
 					<Button

--- a/apps/main/src/components/solid/pulse/PulseCreateIngestKey.tsx
+++ b/apps/main/src/components/solid/pulse/PulseCreateIngestKey.tsx
@@ -1,0 +1,98 @@
+import { getBrowserClient } from "@devpad/core/ui/client";
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader, ModalTitle } from "@f0rbit/ui";
+import Check from "lucide-solid/icons/check";
+import Copy from "lucide-solid/icons/copy";
+import Plus from "lucide-solid/icons/plus";
+import { createSignal, Show } from "solid-js";
+
+interface PulseCreateIngestKeyProps {
+	projectId: string;
+}
+
+export default function PulseCreateIngestKey(props: PulseCreateIngestKeyProps) {
+	const [loading, setLoading] = createSignal(false);
+	const [createdKey, setCreatedKey] = createSignal<string | null>(null);
+	const [error, setError] = createSignal<string | null>(null);
+	const [copied, setCopied] = createSignal(false);
+
+	const handleCreate = async () => {
+		setLoading(true);
+		setError(null);
+		const apiClient = getBrowserClient();
+		const result = await apiClient.pulse.keys.create({
+			project_id: props.projectId,
+			name: "default",
+		});
+		if (!result.ok) {
+			setError(result.error.message ?? "Failed to create ingest key");
+			setLoading(false);
+			return;
+		}
+		setCreatedKey(result.value.plaintext);
+		setLoading(false);
+	};
+
+	const handleCopy = () => {
+		navigator.clipboard.writeText(createdKey()!);
+		setCopied(true);
+		setTimeout(() => setCopied(false), 2000);
+	};
+
+	return (
+		<div class="stack stack-sm">
+			<Button onClick={handleCreate} disabled={loading()} data-testid="pulse-create-key">
+				<Plus size={16} /> {loading() ? "creating..." : "Create ingest key"}
+			</Button>
+			<Show when={error()}>
+				<p class="text-sm" style={{ color: "var(--item-red)", margin: "0" }}>
+					{error()}
+				</p>
+			</Show>
+
+			<Modal open={!!createdKey()} onClose={() => setCreatedKey(null)}>
+				<ModalHeader>
+					<ModalTitle>Ingest key created</ModalTitle>
+				</ModalHeader>
+				<ModalBody>
+					<p class="text-sm" style={{ margin: "0 0 0.75rem 0", color: "var(--item-red)" }}>
+						Copy this key now. It won't be shown again.
+					</p>
+					<code
+						style={{
+							display: "block",
+							padding: "0.75rem",
+							background: "var(--bg-alt)",
+							"border-radius": "4px",
+							"font-size": "var(--text-sm)",
+							"word-break": "break-all",
+							"user-select": "all",
+						}}
+					>
+						{createdKey()}
+					</code>
+				</ModalBody>
+				<ModalFooter>
+					<Button variant="ghost" onClick={handleCopy}>
+						{copied() ? (
+							<>
+								<Check size={16} /> copied
+							</>
+						) : (
+							<>
+								<Copy size={16} /> copy
+							</>
+						)}
+					</Button>
+					<Button
+						onClick={() => {
+							setCreatedKey(null);
+							window.location.reload();
+						}}
+					>
+						done
+					</Button>
+				</ModalFooter>
+			</Modal>
+		</div>
+	);
+}

--- a/apps/main/src/pages/project/[project_id]/pulse.astro
+++ b/apps/main/src/pages/project/[project_id]/pulse.astro
@@ -1,6 +1,7 @@
 ---
 import PageLayout from "@/layouts/PageLayout.astro";
 import ProjectLayout from "@/layouts/ProjectLayout.astro";
+import PulseCreateIngestKey from "@/components/solid/pulse/PulseCreateIngestKey";
 import PulseOverview from "@/components/solid/pulse/PulseOverview";
 import PulseErrors from "@/components/solid/pulse/PulseErrors";
 import PulseLogs from "@/components/solid/pulse/PulseLogs";
@@ -139,16 +140,10 @@ const pulse = createPulse({
 pulse.event("signup", { plan: "pro" });`}</code></pre>
 					{has_ingest_key ? (
 						<p class="text-sm text-faint" style="margin: 0;">
-							This project already has an ingest key (<code>{ingest_key_id}</code>). Re-display it via the API or create a new one.
+							This project already has an ingest key (<code>{ingest_key_id}</code>). Create another one below if you've lost it.
 						</p>
-					) : (
-						<form method="POST" action={`/project/${project_id}/pulse/keys/create`} style="margin: 0;">
-							<button type="submit" class="button" data-testid="pulse-create-key" disabled>
-								Create ingest key (coming soon)
-							</button>
-							<p class="text-sm text-faint" style="margin: 0.25rem 0 0 0;">Use <code>client.pulse.keys.create()</code> from a script for now.</p>
-						</form>
-					)}
+					) : null}
+					<PulseCreateIngestKey projectId={project.id} client:load />
 				</div>
 			)}
 

--- a/packages/api/src/api-client.ts
+++ b/packages/api/src/api-client.ts
@@ -95,12 +95,14 @@ export class ApiClient {
 		keys: {
 			list: (): Promise<ApiResult<ApiKey[]>> => wrap(() => this.clients.auth.get<ApiKey[]>("/keys")),
 
-			create: (name?: string): Promise<ApiResult<{ message: string; key: { key: ApiKey; raw_key: string } }>> =>
-				wrap(() =>
-					this.clients.auth.post<{ message: string; key: { key: ApiKey; raw_key: string } }>("/keys", {
-						body: name ? { name } : {},
-					})
-				),
+			create: (
+				input?: string | { name?: string; scope?: "devpad" | "blog" | "media" | "pulse" | "all" },
+			): Promise<ApiResult<{ message: string; key: { key: ApiKey; raw_key: string } }>> => {
+				const body = typeof input === "string" ? { name: input } : (input ?? {});
+				return wrap(() =>
+					this.clients.auth.post<{ message: string; key: { key: ApiKey; raw_key: string } }>("/keys", { body }),
+				);
+			},
 
 			revoke: (key_id: string): Promise<ApiResult<{ message: string; success: boolean }>> => wrap(() => this.clients.auth.delete<{ message: string; success: boolean }>(`/keys/${key_id}`)),
 


### PR DESCRIPTION
## Two UI gaps closed

1. API key creation modal had no scope picker — users couldn't create pulse-scoped keys via UI. Added a native select inside the existing modal.
2. Pulse dashboard empty state showed a disabled `<button class="button">Create ingest key (coming soon)</button>` with a 'use a script' fallback. Now uses the proper Button component + a Solid island that calls client.pulse.keys.create and surfaces the plaintext.

## Test plan

- [ ] Create an API key with each scope option — DB row has the right scope value
- [ ] On a pulse dashboard empty state, click Create ingest key → plaintext modal renders, key works for /e
- [ ] Existing apiClient.auth.keys.create(name) string call still typechecks (back-compat)