### PR TITLE
refactor(pulse): opinionated log.<level>() API on both sides

### DIFF
--- a/apps/main/src/layouts/Layout.astro
+++ b/apps/main/src/layouts/Layout.astro
@@ -54,9 +54,8 @@ const pulse_ready = Boolean(PULSE_INGEST_URL && DEVPAD_PROJECT_ID && PULSE_INGES
 
 		{pulse_ready && (
 			<script>
-				import { getPulse, installBrowserHandlers } from "@/lib/pulse";
-				getPulse();
-				installBrowserHandlers();
+				// side-effect import: lazy-inits pulse + installs window error handlers.
+				import "@/lib/pulse";
 			</script>
 		)}
 	</head>

--- a/apps/main/src/lib/pulse.ts
+++ b/apps/main/src/lib/pulse.ts
@@ -1,23 +1,39 @@
 /**
  * Pulse analytics + observability for the devpad frontend.
  *
- * Singleton wrapper around @f0rbit/pulse-client. Reads config from
- * `import.meta.env.PUBLIC_*` (build-time inlined) and exposes a clean
- * function surface — no globals on `window`.
+ * Opinionated severity ladder (low → high):
+ *   raw → debug → info → notice → warning → error → critical
  *
  * Usage:
- *   import { track, captureError, pulseLog } from "@/lib/pulse";
- *   track("button_clicked", { id: "save" });
- *   captureError(err, { route: "/tasks" });
- *   pulseLog("warn", "rate limit hit", { ip });
+ *   import { log, track } from "@/lib/pulse";
+ *
+ *   log.info("user signed in", { user_id });
+ *   log.warning("rate limit hit", { ip });
+ *   log.error("payment failed", err, { order_id });   // err optional; Error promotes to a captured exception
+ *   log.critical("db unreachable", err);
+ *
+ *   const span = log.span("fetch_dashboard");
+ *   // ... do work
+ *   span.end({ items: 12 });
+ *
+ *   log.trace("quick_check", { ms: 4 });              // one-shot span
+ *   await log.flush();                                // before navigation/unload
+ *
+ *   track("project_created", { project_id });         // domain event (separate from logs)
+ *
+ * Init is lazy — no-ops cleanly when PUBLIC_PULSE_INGEST_URL / PUBLIC_DEVPAD_PROJECT_ID /
+ * PUBLIC_DEVPAD_PULSE_INGEST_KEY are unset. Browser error handlers attach on first init.
+ * Importing this module in a browser context eagerly initializes — no manual call needed.
  */
 
 import { createPulse, type Pulse } from "@f0rbit/pulse-client";
+import { startSpan, type Span } from "@f0rbit/pulse-client/spans";
 
-type PulseLevel = "debug" | "info" | "warn" | "error" | "critical";
+type LogLevel = "raw" | "debug" | "info" | "notice" | "warning" | "error" | "critical";
 
 let _pulse: Pulse | null = null;
 let _initialized = false;
+let _handlers_installed = false;
 
 const ensureInitialized = (): Pulse | null => {
 	if (_initialized) return _pulse;
@@ -39,51 +55,85 @@ const ensureInitialized = (): Pulse | null => {
 		auto_pageview: true,
 		release,
 	});
+
+	install_browser_handlers(_pulse);
 	return _pulse;
 };
 
-/** Lazy-initialized singleton pulse instance. Null when env vars are unset (no-op). */
-export const getPulse = (): Pulse | null => ensureInitialized();
-
-/** Emit a custom event. Silently no-ops when pulse isn't configured. */
-export const track = (name: string, properties?: Record<string, unknown>): void => {
-	ensureInitialized()?.event(name, properties);
-};
-
-/** Capture an error with optional context. */
-export const captureError = (err: unknown, ctx?: Record<string, unknown>): void => {
-	ensureInitialized()?.captureError(err, ctx);
-};
-
-/** Structured log line. */
-export const pulseLog = (level: PulseLevel, message: string, attrs?: Record<string, unknown>): void => {
-	ensureInitialized()?.log(level, message, attrs);
-};
-
-/** Manually trigger a flush (e.g. before navigation/unload). */
-export const flushPulse = async (): Promise<void> => {
-	await ensureInitialized()?.flush();
-};
-
-/**
- * Wire global window error + unhandled-rejection handlers to captureError.
- * Call once after init (Layout.astro does this).
- */
-export const installBrowserHandlers = (): void => {
-	const p = ensureInitialized();
-	if (!p || typeof window === "undefined") return;
+const install_browser_handlers = (p: Pulse): void => {
+	if (_handlers_installed || typeof window === "undefined") return;
+	_handlers_installed = true;
 
 	window.addEventListener("error", (e: ErrorEvent) => {
-		const err = e.error ?? new Error(e.message);
-		p.captureError(err, {
+		p.captureError(e.error ?? new Error(e.message), {
 			source: "window.onerror",
 			filename: e.filename,
 			lineno: e.lineno,
 			colno: e.colno,
 		});
 	});
-
 	window.addEventListener("unhandledrejection", (e: PromiseRejectionEvent) => {
-		p.captureError(e.reason ?? new Error("unhandledrejection"), { source: "unhandledrejection" });
+		p.captureError(e.reason ?? new Error("unhandledrejection"), {
+			source: "unhandledrejection",
+		});
 	});
 };
+
+const isError = (x: unknown): x is Error =>
+	x instanceof Error || (typeof x === "object" && x !== null && "stack" in (x as Record<string, unknown>));
+
+const emit = (level: LogLevel, message: string, attrs?: Record<string, unknown>): void => {
+	ensureInitialized()?.log(level as never, message, attrs);
+};
+
+const error_or_critical =
+	(level: "error" | "critical") =>
+	(message: string, err_or_attrs?: unknown, attrs?: Record<string, unknown>): void => {
+		const p = ensureInitialized();
+		if (!p) return;
+		if (isError(err_or_attrs)) {
+			p.captureError(err_or_attrs, { message, level, ...attrs });
+			return;
+		}
+		p.log(level, message, err_or_attrs as Record<string, unknown> | undefined);
+	};
+
+/** Opinionated namespaced log surface — see file header for the severity ladder. */
+export const log = {
+	raw: (msg: string, attrs?: Record<string, unknown>) => emit("raw", msg, attrs),
+	debug: (msg: string, attrs?: Record<string, unknown>) => emit("debug", msg, attrs),
+	info: (msg: string, attrs?: Record<string, unknown>) => emit("info", msg, attrs),
+	notice: (msg: string, attrs?: Record<string, unknown>) => emit("notice", msg, attrs),
+	warning: (msg: string, attrs?: Record<string, unknown>) => emit("warning", msg, attrs),
+	/** `log.error(msg, err?, attrs?)` — when an Error is passed it's captured as an exception. */
+	error: error_or_critical("error"),
+	/** `log.critical(msg, err?, attrs?)` — same shape as error, higher severity. */
+	critical: error_or_critical("critical"),
+
+	span(name: string): Span {
+		const p = ensureInitialized();
+		if (!p) return { end: () => {} } as Span;
+		return startSpan({ pulse: p, name });
+	},
+
+	trace(name: string, attrs?: Record<string, unknown>): void {
+		log.span(name).end(attrs);
+	},
+
+	async flush(): Promise<void> {
+		await ensureInitialized()?.flush();
+	},
+};
+
+/** Emit a domain event (e.g. `project_created`) — distinct from a log line. */
+export const track = (name: string, properties?: Record<string, unknown>): void => {
+	ensureInitialized()?.event(name, properties);
+};
+
+/** Lazy singleton pulse instance for advanced use cases (manual flush, custom shapes). */
+export const getPulse = (): Pulse | null => ensureInitialized();
+
+// Eager init in browser context — installs error handlers right away on import.
+if (typeof window !== "undefined") {
+	ensureInitialized();
+}

--- a/packages/worker/src/bindings.ts
+++ b/packages/worker/src/bindings.ts
@@ -2,6 +2,7 @@ import type { SessionData } from "@devpad/core/auth";
 import type { AppContext as BlogAppContext } from "@devpad/core/services/blog";
 import type { AppContext as MediaAppContext } from "@devpad/core/services/media";
 import type { Pulse } from "@f0rbit/pulse-client";
+import type { PulseLog } from "./lib/log.js";
 import type { AuthUser, Bindings } from "@devpad/schema/bindings";
 import type { Database } from "@devpad/schema/database/types";
 
@@ -42,6 +43,7 @@ export type AppVariables = {
 	config: AppConfig;
 	oauth_secrets: OAuthSecrets;
 	pulse?: Pulse;
+	log: PulseLog;
 };
 
 export type AppContext = {

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -8,6 +8,7 @@ import type { Database } from "@devpad/schema/database/types";
 import { create_cloudflare_backend } from "@f0rbit/corpus/cloudflare";
 import { createPulse } from "@f0rbit/pulse-client";
 import { pulseTracing } from "@f0rbit/pulse-client/hono";
+import { make_log, noop_log } from "./lib/log.js";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import type { AppConfig, AppContext, OAuthSecrets } from "./bindings.js";
@@ -93,6 +94,7 @@ export const createApi = (options?: ApiOptions) => {
 	app.use("*", async (c, next) => {
 		const config = c.get("config");
 		if (!config.pulse_api_base || !config.pulse_devpad_ingest_key || !config.devpad_project_id) {
+			c.set("log", noop_log);
 			await next();
 			return;
 		}
@@ -103,6 +105,7 @@ export const createApi = (options?: ApiOptions) => {
 			release: config.git_sha,
 		});
 		c.set("pulse", pulse);
+		c.set("log", make_log(pulse));
 		await pulseTracing({ pulse })(c, next);
 		try {
 			c.executionCtx?.waitUntil(pulse.flush());

--- a/packages/worker/src/lib/log.ts
+++ b/packages/worker/src/lib/log.ts
@@ -1,0 +1,82 @@
+/**
+ * Server-side pulse logger for the devpad worker.
+ *
+ * Mirrors `apps/main/src/lib/pulse.ts`'s `log` namespace so route handlers
+ * call the same surface on both sides of the wire. Set as a request-scoped
+ * context variable (`c.set("log", make_log(pulse))`) by the pulse middleware.
+ * Falls back to `noop_log` when pulse isn't configured so routes never have
+ * to null-check.
+ *
+ *   const log = c.get("log");
+ *   log.info("user signed in", { user_id });
+ *   log.error("payment failed", err, { order_id });   // err optional
+ *   const span = log.span("github_scan"); ...; span.end({ items });
+ */
+
+import type { Pulse } from "@f0rbit/pulse-client";
+import { startSpan, type Span } from "@f0rbit/pulse-client/spans";
+
+type LogLevel = "raw" | "debug" | "info" | "notice" | "warning" | "error" | "critical";
+
+const isError = (x: unknown): x is Error =>
+	x instanceof Error || (typeof x === "object" && x !== null && "stack" in (x as Record<string, unknown>));
+
+export interface PulseLog {
+	raw(msg: string, attrs?: Record<string, unknown>): void;
+	debug(msg: string, attrs?: Record<string, unknown>): void;
+	info(msg: string, attrs?: Record<string, unknown>): void;
+	notice(msg: string, attrs?: Record<string, unknown>): void;
+	warning(msg: string, attrs?: Record<string, unknown>): void;
+	/** `log.error(msg, err?, attrs?)` — Error promotes to a captured exception. */
+	error(msg: string, err_or_attrs?: unknown, attrs?: Record<string, unknown>): void;
+	/** `log.critical(msg, err?, attrs?)` — same shape, higher severity. */
+	critical(msg: string, err_or_attrs?: unknown, attrs?: Record<string, unknown>): void;
+	span(name: string): Span;
+	trace(name: string, attrs?: Record<string, unknown>): void;
+	flush(): Promise<void>;
+}
+
+const NOOP_SPAN: Span = { end: () => {} };
+
+/** No-op logger for when pulse isn't configured (env vars unset). */
+export const noop_log: PulseLog = {
+	raw: () => {},
+	debug: () => {},
+	info: () => {},
+	notice: () => {},
+	warning: () => {},
+	error: () => {},
+	critical: () => {},
+	span: () => NOOP_SPAN,
+	trace: () => {},
+	flush: async () => {},
+};
+
+const emit_level = (pulse: Pulse, level: LogLevel) => (msg: string, attrs?: Record<string, unknown>) =>
+	pulse.log(level as never, msg, attrs);
+
+const emit_error =
+	(pulse: Pulse, level: "error" | "critical") =>
+	(message: string, err_or_attrs?: unknown, attrs?: Record<string, unknown>): void => {
+		if (isError(err_or_attrs)) {
+			pulse.captureError(err_or_attrs, { message, level, ...attrs });
+			return;
+		}
+		pulse.log(level, message, err_or_attrs as Record<string, unknown> | undefined);
+	};
+
+/** Build a `PulseLog` bound to a specific pulse instance. */
+export const make_log = (pulse: Pulse): PulseLog => ({
+	raw: emit_level(pulse, "raw"),
+	debug: emit_level(pulse, "debug"),
+	info: emit_level(pulse, "info"),
+	notice: emit_level(pulse, "notice"),
+	warning: emit_level(pulse, "warning"),
+	error: emit_error(pulse, "error"),
+	critical: emit_error(pulse, "critical"),
+	span: (name: string) => startSpan({ pulse, name }),
+	trace: (name: string, attrs?: Record<string, unknown>) => startSpan({ pulse, name }).end(attrs),
+	flush: async () => {
+		await pulse.flush();
+	},
+});


### PR DESCRIPTION
Replaces pulseLog/captureError with a single namespaced surface (log.raw, log.debug, log.info, log.notice, log.warning, log.error with optional Error arg, log.critical, log.span, log.trace, log.flush). Symmetric on client (apps/main/src/lib/pulse.ts) and server (packages/worker/src/lib/log.ts wired via c.get('log')).