### PR TITLE
feat(observability): domain events on key frontend flows

### DIFF
--- a/apps/main/src/components/solid/ApiKeyManager.tsx
+++ b/apps/main/src/components/solid/ApiKeyManager.tsx
@@ -7,6 +7,7 @@ import Key from "lucide-solid/icons/key";
 import Plus from "lucide-solid/icons/plus";
 import Trash2 from "lucide-solid/icons/trash-2";
 import { createSignal, For, Show } from "solid-js";
+import { track } from "@/lib/pulse";
 
 interface ApiKeyManagerProps {
 	keys: ApiKey[];
@@ -56,6 +57,7 @@ export default function ApiKeyManager(props: ApiKeyManagerProps) {
 			return;
 		}
 		setCreatedKey(result.value.key.raw_key);
+		track("api_key_created", { scope: newKeyScope() });
 		const listResult = await apiClient.auth.keys.list();
 		if (listResult.ok) {
 			setKeys(listResult.value);
@@ -73,6 +75,7 @@ export default function ApiKeyManager(props: ApiKeyManagerProps) {
 		if (result.ok) {
 			setKeys(prev => prev.filter(k => k.id !== deleteTarget()!.id));
 			setDeleteTarget(null);
+			track("api_key_revoked");
 		} else {
 			setError(result.error.message ?? "Failed to delete key");
 		}

--- a/apps/main/src/components/solid/ProjectContextSetter.tsx
+++ b/apps/main/src/components/solid/ProjectContextSetter.tsx
@@ -1,7 +1,11 @@
 import { onMount } from "solid-js";
 import { setProjectContext } from "@/utils/project-context";
+import { track } from "@/lib/pulse";
 
 export function ProjectContextSetter(props: { id: string; name: string }) {
-	onMount(() => setProjectContext({ id: props.id, name: props.name }));
+	onMount(() => {
+		setProjectContext({ id: props.id, name: props.name });
+		track("project_context_set", { project_id: props.id });
+	});
 	return null;
 }

--- a/apps/main/src/components/solid/TaskQuickAdd.tsx
+++ b/apps/main/src/components/solid/TaskQuickAdd.tsx
@@ -3,6 +3,7 @@ import type { TaskWithDetails } from "@devpad/schema";
 import Loader from "lucide-solid/icons/loader";
 import Plus from "lucide-solid/icons/plus";
 import { createSignal, Show } from "solid-js";
+import { track } from "@/lib/pulse";
 
 interface Props {
 	project_id: string;
@@ -41,6 +42,7 @@ export function TaskQuickAdd({ project_id, user_id, onCreated }: Props) {
 		setTitle("");
 		setPriority("LOW");
 		onCreated(result.value);
+		track("task_created", { project_id, task_id: (result.value as { id?: string })?.id });
 	};
 
 	const handleKeyDown = (e: KeyboardEvent) => {

--- a/apps/main/src/components/solid/pulse/PulseCreateIngestKey.tsx
+++ b/apps/main/src/components/solid/pulse/PulseCreateIngestKey.tsx
@@ -4,6 +4,7 @@ import Check from "lucide-solid/icons/check";
 import Copy from "lucide-solid/icons/copy";
 import Plus from "lucide-solid/icons/plus";
 import { createSignal, Show } from "solid-js";
+import { track } from "@/lib/pulse";
 
 interface PulseCreateIngestKeyProps {
 	projectId: string;
@@ -29,6 +30,7 @@ export default function PulseCreateIngestKey(props: PulseCreateIngestKeyProps) {
 			return;
 		}
 		setCreatedKey(result.value.plaintext);
+		track("pulse_ingest_key_created", { project_id: props.projectId });
 		setLoading(false);
 	};
 


### PR DESCRIPTION
Adds 5 track() calls at high-signal moments: API key lifecycle, pulse ingest key creation, project context, task creation. All additive 1-line edits.