### PR TITLE
feat(observability): pulse log + span on key worker paths

### DIFF
--- a/packages/worker/src/middleware/auth.ts
+++ b/packages/worker/src/middleware/auth.ts
@@ -58,6 +58,11 @@ export const authMiddleware = createMiddleware<AppContext>(async (c, next) => {
 		c.header("Set-Cookie", createBlankSessionCookie(cookieConfig(config.environment)));
 	}
 
+	const log = c.get("log");
+	if (log) {
+		log.warning("auth_failed", { path: c.req.path, has_session: Boolean(c.req.header("cookie")) });
+	}
+
 	setNullAuth(c);
 	return next();
 });

--- a/packages/worker/src/routes/auth.ts
+++ b/packages/worker/src/routes/auth.ts
@@ -95,7 +95,7 @@ app.get("/callback/github", async c => {
 	if (!callback_result.ok) return c.json({ error: "OAuth callback failed", detail: callback_result.error }, 500);
 
 	const { sessionId, user: callback_user } = callback_result.value;
-	c.get("log").info("login_success", { user_id: callback_user.id, provider: "github" });
+	c.get("log")?.info("login_success", { user_id: callback_user.id, provider: "github" });
 	console.log(`[auth/callback] session created: ${sessionId.substring(0, 8)}...`);
 
 	const cookie_config = cookieConfig(config.environment);
@@ -162,7 +162,7 @@ app.get("/session", async c => {
 	const full_user_result = await users.getUserById(db, user.id);
 	const full_user = full_user_result.ok ? full_user_result.value : null;
 
-	c.get("log").info("session_check_ok", { user_id: user.id, scope: api_key_scope });
+	c.get("log")?.info("session_check_ok", { user_id: user.id, scope: api_key_scope });
 
 	return c.json({
 		authenticated: true,

--- a/packages/worker/src/routes/auth.ts
+++ b/packages/worker/src/routes/auth.ts
@@ -94,7 +94,8 @@ app.get("/callback/github", async c => {
 	const callback_result = await oauth.handleGitHubCallback(db, oauth_env, code, state, stored_state);
 	if (!callback_result.ok) return c.json({ error: "OAuth callback failed", detail: callback_result.error }, 500);
 
-	const { sessionId } = callback_result.value;
+	const { sessionId, user: callback_user } = callback_result.value;
+	c.get("log").info("login_success", { user_id: callback_user.id, provider: "github" });
 	console.log(`[auth/callback] session created: ${sessionId.substring(0, 8)}...`);
 
 	const cookie_config = cookieConfig(config.environment);
@@ -160,6 +161,8 @@ app.get("/session", async c => {
 
 	const full_user_result = await users.getUserById(db, user.id);
 	const full_user = full_user_result.ok ? full_user_result.value : null;
+
+	c.get("log").info("session_check_ok", { user_id: user.id, scope: api_key_scope });
 
 	return c.json({
 		authenticated: true,

--- a/packages/worker/src/routes/v1/keys.ts
+++ b/packages/worker/src/routes/v1/keys.ts
@@ -31,7 +31,7 @@ app.post("/", requireAuth, async c => {
 	const result = await keys.createApiKey(db, auth_user.id, parsed.data.scope ?? "devpad", parsed.data.name);
 	if (!result.ok) return c.json({ error: "Failed to create API key" }, 500);
 
-	c.get("log").info("api_key_minted", { user_id: auth_user.id, scope: parsed.data.scope ?? "devpad" });
+	c.get("log")?.info("api_key_minted", { user_id: auth_user.id, scope: parsed.data.scope ?? "devpad" });
 	return c.json({ message: "API key created successfully", key: result.value });
 });
 
@@ -48,7 +48,7 @@ app.delete("/:key_id", requireAuth, async c => {
 		return c.json({ error: "Failed to delete API key" }, 500);
 	}
 
-	c.get("log").info("api_key_revoked", { user_id: auth_user.id });
+	c.get("log")?.info("api_key_revoked", { user_id: auth_user.id });
 	return c.json({ message: "API key deleted successfully", success: true });
 });
 

--- a/packages/worker/src/routes/v1/keys.ts
+++ b/packages/worker/src/routes/v1/keys.ts
@@ -31,11 +31,13 @@ app.post("/", requireAuth, async c => {
 	const result = await keys.createApiKey(db, auth_user.id, parsed.data.scope ?? "devpad", parsed.data.name);
 	if (!result.ok) return c.json({ error: "Failed to create API key" }, 500);
 
+	c.get("log").info("api_key_minted", { user_id: auth_user.id, scope: parsed.data.scope ?? "devpad" });
 	return c.json({ message: "API key created successfully", key: result.value });
 });
 
 app.delete("/:key_id", requireAuth, async c => {
 	const db = c.get("db");
+	const auth_user = c.get("user")!;
 	const key_id = c.req.param("key_id");
 
 	if (!key_id) return c.json({ error: "Key ID required" }, 400);
@@ -46,6 +48,7 @@ app.delete("/:key_id", requireAuth, async c => {
 		return c.json({ error: "Failed to delete API key" }, 500);
 	}
 
+	c.get("log").info("api_key_revoked", { user_id: auth_user.id });
 	return c.json({ message: "API key deleted successfully", success: true });
 });
 

--- a/packages/worker/src/routes/v1/pulse.ts
+++ b/packages/worker/src/routes/v1/pulse.ts
@@ -58,12 +58,12 @@ const forward_to_pulse = async (c: Context<AppContext>, opts: ForwardOpts): Prom
 	try {
 		response = await fetch(url.toString(), fetch_options);
 	} catch {
-		c.get("log").warning("pulse_proxy_unreachable", { pulse_path: opts.pulse_path });
+		c.get("log")?.warning("pulse_proxy_unreachable", { pulse_path: opts.pulse_path });
 		return c.json({ error: "pulse_unreachable" }, 503);
 	}
 
 	if (response.status === 502 || response.status === 503) {
-		c.get("log").warning("pulse_proxy_unreachable", { pulse_path: opts.pulse_path });
+		c.get("log")?.warning("pulse_proxy_unreachable", { pulse_path: opts.pulse_path });
 		return c.json({ error: "pulse_unreachable" }, 503);
 	}
 
@@ -88,7 +88,7 @@ const guard_project_owner = async (c: Context<AppContext>, project_id: string): 
 
 	const ownership = await projects.doesUserOwnProject(db, user.id, project_id);
 	if (!ownership.ok || !ownership.value) {
-		c.get("log").warning("pulse_proxy_forbidden", { project_id, user_id: user.id });
+		c.get("log")?.warning("pulse_proxy_forbidden", { project_id, user_id: user.id });
 		return c.json({ error: "Forbidden" }, 403);
 	}
 	return null;

--- a/packages/worker/src/routes/v1/pulse.ts
+++ b/packages/worker/src/routes/v1/pulse.ts
@@ -58,10 +58,12 @@ const forward_to_pulse = async (c: Context<AppContext>, opts: ForwardOpts): Prom
 	try {
 		response = await fetch(url.toString(), fetch_options);
 	} catch {
+		c.get("log").warning("pulse_proxy_unreachable", { pulse_path: opts.pulse_path });
 		return c.json({ error: "pulse_unreachable" }, 503);
 	}
 
 	if (response.status === 502 || response.status === 503) {
+		c.get("log").warning("pulse_proxy_unreachable", { pulse_path: opts.pulse_path });
 		return c.json({ error: "pulse_unreachable" }, 503);
 	}
 
@@ -85,7 +87,10 @@ const guard_project_owner = async (c: Context<AppContext>, project_id: string): 
 	if (!user) return c.json({ error: "Unauthorized" }, 401);
 
 	const ownership = await projects.doesUserOwnProject(db, user.id, project_id);
-	if (!ownership.ok || !ownership.value) return c.json({ error: "Forbidden" }, 403);
+	if (!ownership.ok || !ownership.value) {
+		c.get("log").warning("pulse_proxy_forbidden", { project_id, user_id: user.id });
+		return c.json({ error: "Forbidden" }, 403);
+	}
 	return null;
 };
 

--- a/packages/worker/src/routes/v1/scanning.ts
+++ b/packages/worker/src/routes/v1/scanning.ts
@@ -24,12 +24,16 @@ app.post("/scan", requireAuth, async c => {
 	const project_id = c.req.query("project_id");
 	if (!project_id) return c.json({ error: "project_id parameter required" }, 400);
 
+	const log = c.get("log");
+	const span = log.span("github_scan");
 	return stream(c, async s => {
 		try {
 			for await (const chunk of scanning.initiateScan(db, project_id, auth_user.id, session.access_token!)) {
 				await s.write(chunk);
 			}
+			span.end({ status: "ok", project_id });
 		} catch {
+			span.end({ status: "error", project_id });
 			await s.write("error: scan failed\n");
 		}
 	});

--- a/packages/worker/src/routes/v1/scanning.ts
+++ b/packages/worker/src/routes/v1/scanning.ts
@@ -25,7 +25,7 @@ app.post("/scan", requireAuth, async c => {
 	if (!project_id) return c.json({ error: "project_id parameter required" }, 400);
 
 	const log = c.get("log");
-	const span = log.span("github_scan");
+	const span = log?.span("github_scan") ?? { end: () => {} };
 	return stream(c, async s => {
 		try {
 			for await (const chunk of scanning.initiateScan(db, project_id, auth_user.id, session.access_token!)) {


### PR DESCRIPTION
## Summary
- Adds `c.get("log").*()` instrumentation at 5 high-signal worker paths.
- Pure additions — no refactors, no new deps, no behavior changes.
- Sibling branch `feat/observability-frontend` (PR #119) covers frontend; different files, no conflict.

## Instrumentations
| File | Line | Kind | Event |
|---|---|---|---|
| `packages/worker/src/middleware/auth.ts` | 61 | `warning` | `auth_failed` |
| `packages/worker/src/routes/v1/keys.ts` | 34 | `info` | `api_key_minted` |
| `packages/worker/src/routes/v1/keys.ts` | 52 | `info` | `api_key_revoked` |
| `packages/worker/src/routes/v1/pulse.ts` | 61 | `warning` | `pulse_proxy_unreachable` (catch) |
| `packages/worker/src/routes/v1/pulse.ts` | 66 | `warning` | `pulse_proxy_unreachable` (502/503) |
| `packages/worker/src/routes/v1/pulse.ts` | 90 | `warning` | `pulse_proxy_forbidden` |
| `packages/worker/src/routes/auth.ts` | 99 | `info` | `login_success` |
| `packages/worker/src/routes/auth.ts` | 166 | `info` | `session_check_ok` |
| `packages/worker/src/routes/v1/scanning.ts` | 28-39 | `span` | `github_scan` |

## Test plan
- [x] `bun check` in `apps/main` — only pre-existing `OptimisticTaskProgress.tsx:41` error remains; no new errors.
- [x] `tsc --noEmit` in `packages/worker` — no errors in any of the 5 modified files (pre-existing rootDir + blog/posts errors unchanged).
- [ ] Live verification post-deploy: `auth_failed` warnings flow to pulse when an unauthenticated request hits an authed route.
- [ ] `github_scan` span appears in pulse for `/api/v1/scan` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)