### PR TITLE
feat(ui): welcome banner for new users on /project

### DIFF
--- a/apps/main/src/components/solid/WelcomeBanner.tsx
+++ b/apps/main/src/components/solid/WelcomeBanner.tsx
@@ -1,0 +1,119 @@
+import { Badge, Button } from "@f0rbit/ui";
+import ChevronRight from "lucide-solid/icons/chevron-right";
+import FolderPlus from "lucide-solid/icons/folder-plus";
+import Github from "lucide-solid/icons/github";
+import ListChecks from "lucide-solid/icons/list-checks";
+import ScanText from "lucide-solid/icons/scan-text";
+import X from "lucide-solid/icons/x";
+import { createSignal, For, onMount, Show } from "solid-js";
+
+const DISMISS_KEY = "devpad_welcome_dismissed";
+
+interface Props {
+	project_count: number;
+}
+
+interface Step {
+	icon: typeof FolderPlus;
+	title: string;
+	description: string;
+	href: string | null;
+}
+
+const STEPS: Step[] = [
+	{
+		icon: FolderPlus,
+		title: "create a project",
+		description: "give it a name, description, and status",
+		href: "/project/create",
+	},
+	{
+		icon: Github,
+		title: "link a github repo",
+		description: "connect a repository to enable code scanning",
+		href: "/project/create",
+	},
+	{
+		icon: ScanText,
+		title: "run your first scan",
+		description: "scan your codebase for TODO and FIXME comments",
+		href: null,
+	},
+	{
+		icon: ListChecks,
+		title: "manage your tasks",
+		description: "review scanned tasks, set priorities, track progress",
+		href: "/todo",
+	},
+];
+
+export function WelcomeBanner(props: Props) {
+	const [visible, setVisible] = createSignal(false);
+
+	onMount(() => {
+		if (props.project_count > 0) return;
+		const dismissed = localStorage.getItem(DISMISS_KEY);
+		if (dismissed) return;
+		setVisible(true);
+	});
+
+	const dismiss = () => {
+		setVisible(false);
+		localStorage.setItem(DISMISS_KEY, "true");
+	};
+
+	return (
+		<Show when={visible()}>
+			<div
+				class="stack stack-sm"
+				style={{
+					border: "1px solid var(--border)",
+					"border-radius": "6px",
+					padding: "16px 20px",
+					"margin-bottom": "16px",
+					background: "var(--bg-alt)",
+				}}
+			>
+				<div class="row row-between">
+					<div class="row row-sm">
+						<h4 style={{ margin: 0 }}>welcome to devpad</h4>
+						<Badge variant="accent">getting started</Badge>
+					</div>
+					<Button variant="ghost" size="sm" onClick={dismiss} aria-label="dismiss welcome banner">
+						<X size={16} />
+					</Button>
+				</div>
+				<p style={{ color: "var(--fg-subtle)", margin: 0 }}>here's how to get started:</p>
+				<ol class="stack stack-sm" style={{ "list-style": "none", padding: 0, margin: 0 }}>
+					<For each={STEPS}>
+						{(step, i) => (
+							<li class="row row-start" style={{ gap: "10px" }}>
+								<span style={{ color: "var(--accent)", "flex-shrink": 0, "margin-top": "2px", "min-width": "20px" }}>
+									<step.icon size={18} />
+								</span>
+								<div class="stack" style={{ gap: "2px", flex: 1 }}>
+									<div class="row row-sm">
+										<strong style={{ color: "var(--fg)" }}>
+											{i() + 1}. {step.title}
+										</strong>
+										<Show when={step.href}>
+											<a
+												href={step.href!}
+												class="row row-sm"
+												style={{ "font-size": "smaller", color: "var(--accent)", "text-decoration": "none" }}
+												aria-label={`go to ${step.title}`}
+											>
+												<ChevronRight size={14} />
+											</a>
+										</Show>
+									</div>
+									<span style={{ "font-size": "smaller", color: "var(--fg-subtle)" }}>{step.description}</span>
+								</div>
+							</li>
+						)}
+					</For>
+				</ol>
+			</div>
+		</Show>
+	);
+}

--- a/apps/main/src/pages/project/index.astro
+++ b/apps/main/src/pages/project/index.astro
@@ -1,6 +1,7 @@
 ---
 import GithubLogin from "@/components/solid/GithubLogin";
 import { ProjectCardGrid } from "../../components/solid/ProjectCardGrid";
+import { WelcomeBanner } from "@/components/solid/WelcomeBanner";
 import PageLayout from "@/layouts/PageLayout.astro";
 import { getServerApiClient } from "@devpad/core/ui/api-client";
 import { rethrow } from "@/utils/api-client";
@@ -62,6 +63,7 @@ const keywords = [
             <h1>projects</h1>
             <a href="/project/create">+ add</a>
           </div>
+          <WelcomeBanner project_count={projects.length} client:load />
           <ProjectCardGrid projects={projects} client:load />
         </section>
       </main>


### PR DESCRIPTION
## Summary

Finishes Phase 4 of `.plans/ux-improvements.md` — first-run onboarding banner on `/project` for users with zero projects.

- New `apps/main/src/components/solid/WelcomeBanner.tsx` (~119 LOC) — dismissible via `localStorage["devpad_welcome_dismissed"]`. Uses `@f0rbit/ui` `Badge` + `Button` primitives. SSR-safe (`visible=false` until `onMount` checks conditions).
- Wired into `apps/main/src/pages/project/index.astro` (+2 lines: import + tag).

**Plan deviations from spec** (intentional, follow project conventions):

1. CSS lives inline in the component, not in `globals.css` — matches `AGENTS.md` guidance ("Avoid adding custom CSS classes to `globals.css` — use `@f0rbit/ui` classes, components, and inline styles instead") and matches how `TaskQuickAdd.tsx` was built in Phase 2.
2. Uses `@f0rbit/ui` `Badge` + `Button` instead of raw `<a role="button">` — same library, more semantic.

**Task 3.5 was already on `main`** (`apps/main/src/pages/project/index.astro:169-171` clears `sessionStorage["devpad_project_context"]` on every visit to `/project`) — no code change needed for that part of the plan.

## Test plan

- [ ] `cd apps/main && bun check` — typecheck passes (no new errors; 2 pre-existing ones in `OptimisticTaskProgress.tsx` + `Layout.astro` unchanged)
- [ ] `bunx --bun astro build` — production build succeeds; `WelcomeBanner` ships as ~3.3KB client-load bundle
- [ ] Manual: visit `/project` as a new user (0 projects) → banner appears; dismiss it → reload → banner stays gone
- [ ] Manual: visit `/project` as a user with projects → no banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)