### PR TITLE
feat(cli): add tasks update subcommand for partial task edits

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import { Command } from "commander";
 import { Table } from "console-table-printer";
 import { register_pipelines_commands } from "./commands/pipelines";
 import { make_spinner as createSpinner } from "./printer";
+import { type TaskUpdateOptions, build_task_update_input } from "./task-update";
 
 // Helper to get API client
 function getApiClient(): ApiClient {
@@ -241,6 +242,34 @@ tasks
 			console.log(chalk.green(`ID: ${String(result.id)}`));
 		} catch (error) {
 			spinner.fail("Failed to create task");
+			handleError(error);
+		}
+	});
+
+tasks
+	.command("update <id>")
+	.description("Update a task (partial — only provided flags change)")
+	.option("--status <status>", "Task status (todo|in_progress|done)")
+	.option("-t, --title <title>", "Task title")
+	.option("-s, --summary <summary>", "Task summary")
+	.option("--priority <priority>", "Task priority (low|medium|high)")
+	.action(async (id, options: TaskUpdateOptions) => {
+		const input = build_task_update_input(id, options);
+		if (!input) {
+			handleError(new Error("No fields to update — pass at least one of --status, --title, --summary, --priority"));
+			return;
+		}
+
+		const spinner = createSpinner("Updating task...").start();
+		try {
+			const tool = getTool("devpad_tasks_upsert");
+			if (!tool) throw new Error("Tool not found");
+
+			const client = getApiClient();
+			const result = await tool.execute(client, input);
+			spinner.succeed(`Task "${String(result.title)}" updated`);
+		} catch (error) {
+			spinner.fail("Failed to update task");
 			handleError(error);
 		}
 	});

--- a/packages/cli/src/task-update.ts
+++ b/packages/cli/src/task-update.ts
@@ -1,0 +1,33 @@
+export type TaskUpdateOptions = {
+	status?: string;
+	title?: string;
+	summary?: string;
+	priority?: string;
+};
+
+export type TaskUpdateInput = {
+	id: string;
+	title?: string;
+	summary?: string;
+	priority?: string;
+	progress?: "TODO" | "IN_PROGRESS" | "DONE";
+};
+
+const task_status_to_progress = (status?: string): TaskUpdateInput["progress"] => {
+	if (status === "done") return "DONE";
+	if (status === "in_progress") return "IN_PROGRESS";
+	if (status === "todo") return "TODO";
+	return undefined;
+};
+
+export function build_task_update_input(id: string, options: TaskUpdateOptions): TaskUpdateInput | null {
+	if (!options.status && !options.title && !options.summary && !options.priority) return null;
+
+	return {
+		id,
+		title: options.title,
+		summary: options.summary,
+		priority: options.priority ? options.priority.toUpperCase() : undefined,
+		progress: task_status_to_progress(options.status),
+	};
+}

--- a/packages/cli/tests/unit/tasks-update.test.ts
+++ b/packages/cli/tests/unit/tasks-update.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for the `tasks update <id>` CLI command's pure input-building
+ * helper (src/task-update.ts). `build_task_update_input` decides which
+ * fields the `devpad_tasks_upsert` MCP tool call receives (partial update)
+ * and signals "no flags given" via a null return.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { build_task_update_input } from "../../src/task-update";
+
+describe("build_task_update_input", () => {
+	test("returns null when no fields are provided", () => {
+		expect(build_task_update_input("task_1", {})).toBeNull();
+	});
+
+	test("maps status to the upstream progress enum", () => {
+		expect(build_task_update_input("task_1", { status: "done" })).toEqual({
+			id: "task_1",
+			title: undefined,
+			summary: undefined,
+			priority: undefined,
+			progress: "DONE",
+		});
+		expect(build_task_update_input("task_1", { status: "in_progress" })?.progress).toBe("IN_PROGRESS");
+		expect(build_task_update_input("task_1", { status: "todo" })?.progress).toBe("TODO");
+	});
+
+	test("uppercases priority", () => {
+		expect(build_task_update_input("task_1", { priority: "high" })).toEqual({
+			id: "task_1",
+			title: undefined,
+			summary: undefined,
+			priority: "HIGH",
+			progress: undefined,
+		});
+	});
+
+	test("only sets the fields that were passed (partial update)", () => {
+		const input = build_task_update_input("task_1", { title: "new title" });
+		expect(input).toEqual({
+			id: "task_1",
+			title: "new title",
+			summary: undefined,
+			priority: undefined,
+			progress: undefined,
+		});
+	});
+
+	test("combines multiple flags", () => {
+		const input = build_task_update_input("task_1", {
+			title: "renamed",
+			summary: "new summary",
+			priority: "low",
+			status: "in_progress",
+		});
+		expect(input).toEqual({
+			id: "task_1",
+			title: "renamed",
+			summary: "new summary",
+			priority: "LOW",
+			progress: "IN_PROGRESS",
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- `devpad tasks update <id>` — partial update via `--status todo|in_progress|done`, `--title`, `--summary`, `--priority low|medium|high`; only supplied flags change; errors cleanly with no flags or an unknown task id.
- Reuses the existing `devpad_tasks_upsert` MCP tool (same primitive `tasks done`/`tasks todo` already call) — no new API surface added.
- Patch-building logic extracted to a pure function (`src/task-update.ts`) so it's unit-testable without spinning up the Commander program.

Rationale: the agent orchestration workflow marks a phase's devpad task `in_progress` at phase start; the CLI only supported `done`/`todo`, forcing MCP use. This closes that gap as part of migrating agent tooling off the devpad MCP onto this CLI.

## Test plan
- [x] `bun test tests/unit` in `packages/cli` — 67 pass, 0 fail
- [x] `bun run typecheck` in `packages/cli` — no new errors vs. main baseline (same pre-existing `TS18046 result: unknown` pattern, unchanged count)
- [x] `bun run build` succeeds
- [x] Manually verified `tasks update --help` and the no-flags error path against built `dist/index.js`